### PR TITLE
[libqofono] Emit property change notifications signals when setting modemPath

### DIFF
--- a/src/qofonoconnectionmanager.h
+++ b/src/qofonoconnectionmanager.h
@@ -91,6 +91,8 @@ private slots:
     void onContextRemove(const QDBusObjectPath &path);
 
 private:
+    void updateProperty(const QString &property, const QVariant &value);
+
     QOfonoConnectionManagerPrivate *d_ptr;
 };
 

--- a/src/qofononetworkregistration.h
+++ b/src/qofononetworkregistration.h
@@ -104,6 +104,8 @@ Q_SIGNALS:
 public slots:
 
 private:
+    void updateProperty(const QString &property, const QVariant &value);
+
     QOfonoNetworkRegistrationPrivate *d_ptr;
 
 private slots:

--- a/src/qofonoradiosettings.h
+++ b/src/qofonoradiosettings.h
@@ -67,6 +67,8 @@ Q_SIGNALS:
 public slots:
     
 private:
+    void updateProperty(const QString &property, const QVariant &value);
+
     QOfonoRadioSettingsPrivate *d_ptr;
 private slots:
     void propertyChanged(const QString &property,const QDBusVariant &value);


### PR DESCRIPTION
Setting the modemPath causes the local object to connect to a different
remote object. The local cached value of the remote object's properties
were being updated correctly, however, the property change notification
signals were not being emitted preventing QML bindings using those
properties from being reevaluated.

Removed redundant conditional tests either because they were unneeded
or because they had only one possible outcome.
