### PR TITLE
Fix compilation for Qt4 and remove QT_VERSION_4 define

### DIFF
--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -6,7 +6,6 @@ CONFIG += plugin
 QT_VERSION=$$[QT_VERSION]
 
 equals(QT_MAJOR_VERSION, 4):{
-    DEFINES += QT_VERSION_4
     QT += declarative
     PLUGIN_TYPE = declarative
     LIBS += -L../src -lqofono

--- a/plugin/qofonodeclarativeplugin.cpp
+++ b/plugin/qofonodeclarativeplugin.cpp
@@ -111,7 +111,7 @@ void QOfonoDeclarativePlugin::registerTypes(const char *uri)
 
 }
 
-#ifdef QT_VERSION_4
+#if QT_VERSION < 0x050000
 void QOfonoDeclarativePlugin::initializeEngine(QDeclarativeEngine *engine, const char *uri)
 {
     Q_UNUSED(uri);

--- a/plugin/qofonodeclarativeplugin.h
+++ b/plugin/qofonodeclarativeplugin.h
@@ -18,7 +18,7 @@
 
 #include "qofono_global.h"
 
-#ifdef QT_VERSION_4
+#if QT_VERSION < 0x050000
 #include <QtDeclarative/qdeclarative.h>
 #include <QtDeclarative/QDeclarativeExtensionPlugin>
 class QOFONOSHARED_EXPORT QOfonoDeclarativePlugin : public QDeclarativeExtensionPlugin
@@ -29,12 +29,12 @@ class QOFONOSHARED_EXPORT QOfonoDeclarativePlugin : public QQmlExtensionPlugin
 #endif
 {
     Q_OBJECT
-#ifndef QT_VERSION_4
+#if QT_VERSION >= 0x050000
     Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QQmlExtensionInterface" FILE "plugin.json")
 #endif
 public:
     void registerTypes(const char *uri);
-#ifdef QT_VERSION_4
+#if QT_VERSION < 0x050000
     void initializeEngine(QDeclarativeEngine *engine, const char *uri);
 #endif
 };

--- a/src/qofonoconnectioncontext.h
+++ b/src/qofonoconnectioncontext.h
@@ -88,7 +88,11 @@ public:
 
     Q_INVOKABLE bool validateProvisioning(); //check provision against mbpi
     Q_INVOKABLE bool validateProvisioning(const QString &provider, const QString &mcc, const QString &mnc); //check provision against mbpi
+    #if QT_VERSION < 0x050000
+    Q_INVOKABLE void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type="internet");
+    #else
     Q_INVOKABLE void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type=QStringLiteral("internet")); // provision context against mbpi
+    #endif
     Q_INVOKABLE void provisionForCurrentNetwork(const QString &type);
 
 Q_SIGNALS:


### PR DESCRIPTION
- QStringLiteral used in qofonoconnectioncontext.h is Qt5 only
  check Qt version before using it.
- Remove the QT_VERSION_4 define use the QT_VERSION macro instead.

Signed-off-by: Ivan Pintado vpintado@cercacor.com
