### PR TITLE
[libqofono-qt5] delay slightly getting simmmanager properties.

### DIFF
--- a/src/qofonosimmanager.h
+++ b/src/qofonosimmanager.h
@@ -151,6 +151,9 @@ private slots:
     void resetPinCallFinished(QDBusPendingCallWatcher *call);
     void lockPinCallFinished(QDBusPendingCallWatcher *call);
     void unlockPinCallFinished(QDBusPendingCallWatcher *call);
+
+    void getAllProperties();
+
 };
 
 #endif // QOFONOSimManager_H


### PR DESCRIPTION
This works around an issue when thie object is created before ofonod
is started/ready, and is slow to produce it's properties.
