### PR TITLE
[libqofono] Add missing emergencyNumbers property NOTIFY macro

### DIFF
--- a/src/qofonovoicecallmanager.h
+++ b/src/qofonovoicecallmanager.h
@@ -31,7 +31,7 @@ class QOFONOSHARED_EXPORT QOfonoVoiceCallManager : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)
-    Q_PROPERTY(QStringList emergencyNumbers READ emergencyNumbers)
+    Q_PROPERTY(QStringList emergencyNumbers READ emergencyNumbers NOTIFY emergencyNumbersChanged)
     Q_PROPERTY(QString errorMessage READ errorMessage)
 
 public:


### PR DESCRIPTION
AFAIK Not needed for anything, just noticed NOTIFY macro missing even though respective signal is emitted.
