### PR TITLE
Added QOfonoConnectionContext::disconnect()

### DIFF
--- a/src/qofonoconnectioncontext.cpp
+++ b/src/qofonoconnectioncontext.cpp
@@ -334,6 +334,15 @@ void QOfonoConnectionContext::setPropertyFinished(QDBusPendingCallWatcher *watch
 
 }
 
+void QOfonoConnectionContext::disconnect()
+{
+    Q_EMIT disconnectRequested();
+    QString active("Active");
+    QDBusPendingReply <> reply = d_ptr->context->SetProperty(active,QDBusVariant(false));
+    reply.waitForFinished();
+    d_ptr->properties[active] = false;
+}
+
 /*
  * These provisioning functions use the mobile broadband provider info database available from this url:
  * https://git.gnome.org/browse/mobile-broadband-provider-info/

--- a/src/qofonoconnectioncontext.h
+++ b/src/qofonoconnectioncontext.h
@@ -94,6 +94,7 @@ public:
     Q_INVOKABLE void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type=QStringLiteral("internet")); // provision context against mbpi
     #endif
     Q_INVOKABLE void provisionForCurrentNetwork(const QString &type);
+    Q_INVOKABLE void disconnect();
 
 Q_SIGNALS:
     void disconnectRequested();


### PR DESCRIPTION
It may be convenient to synchronously deactivate the context, for example, prior to modifying settings. Other SetProperty calls will fail while context is still active.
