### PR TITLE
[libqofono] Don't change DBus properties unless they change.

### DIFF
--- a/src/qofonoconnectionmanager.cpp
+++ b/src/qofonoconnectionmanager.cpp
@@ -207,6 +207,9 @@ bool QOfonoConnectionManager::roamingAllowed() const
 
 void QOfonoConnectionManager::setRoamingAllowed(bool value)
 {
+    if (roamingAllowed() == value)
+        return;
+
     QString str("RoamingAllowed");
     QDBusVariant var(value);
     setOneProperty(str,var);
@@ -222,6 +225,9 @@ bool QOfonoConnectionManager::powered() const
 
 void QOfonoConnectionManager::setPowered(bool value)
 {
+    if (powered() == value)
+        return;
+
     QString str("Powered");
     QDBusVariant var(value);
     setOneProperty(str,var);


### PR DESCRIPTION
If the local cached value of a DBus property is the same as the new
value don't bother sending the DBus command.
