### PR TITLE
[libqofono] Correct property type.

### DIFF
--- a/src/qofonomodem.h
+++ b/src/qofonomodem.h
@@ -49,7 +49,7 @@ class QOFONOSHARED_EXPORT QOfonoModem : public QObject
     Q_PROPERTY(QStringList interfaces READ interfaces NOTIFY interfacesChanged)
 
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)
-    Q_PROPERTY(QString valid READ isValid NOTIFY validChanged)
+    Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)
 
 public:
     explicit QOfonoModem(QObject *parent = 0);


### PR DESCRIPTION
The QOfonoModem::valid property was declared as type QString in
Q_PROPERTY when it is in fact a bool.
