### PR TITLE
Use QT_INSTALL_LIBS for library install paths

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -10,12 +10,12 @@ include(version.pri)
 
 equals(QT_MAJOR_VERSION, 4): {
     TARGET = qofono
-    pkgconfig.path = $$INSTALL_ROOT$$PREFIX/lib/pkgconfig
+    pkgconfig.path = $$[QT_INSTALL_LIBS]/pkgconfig
 }
 
 equals(QT_MAJOR_VERSION, 5): {
     TARGET = qofono-qt5
-    pkgconfig.path = $$INSTALL_ROOT$$PREFIX/lib/pkgconfig-qt5
+    pkgconfig.path = $$[QT_INSTALL_LIBS]/pkgconfig-qt5
 }
 
 TEMPLATE = lib
@@ -203,7 +203,7 @@ equals(QT_MAJOR_VERSION, 5): {
     xmlfiles.path = $$INSTALL_ROOT$$PREFIX/include/qofono-qt5/dbus
 }
 
-target.path = $$INSTALL_ROOT$$PREFIX/lib
+target.path = $$[QT_INSTALL_LIBS]
 headers.files = $$PUBLIC_HEADERS
 
 dbusheaders.files = $$DBUS_HEADERS

--- a/test/auto/tests/testcase.pri
+++ b/test/auto/tests/testcase.pri
@@ -4,12 +4,12 @@ INCLUDEPATH += ../lib ../
 
 equals(QT_MAJOR_VERSION, 4): {
     LIBS += -L../../../src -lqofono
-    target.path = $$INSTALL_ROOT$$PREFIX/lib/libqofono/tests
+    target.path = $$[QT_INSTALL_LIBS]/libqofono/tests
 }
 
 equals(QT_MAJOR_VERSION, 5): {
     LIBS += -L../../../src -lqofono-qt5
-    target.path = $$INSTALL_ROOT$$PREFIX/lib/libqofono-qt5/tests
+    target.path = $$[QT_INSTALL_LIBS]/libqofono-qt5/tests
 
 }
 INSTALLS += target

--- a/test/auto/tst_qofono/tst_qofono.pro
+++ b/test/auto/tst_qofono/tst_qofono.pro
@@ -10,12 +10,12 @@ QT -= gui
 equals(QT_MAJOR_VERSION, 4): {
     LIBS +=  -lqofono
     TARGET = tst_qofonotest
-    target.path = $$INSTALL_ROOT$$PREFIX/lib/libqofono/tests
+    target.path = $$[QT_INSTALL_LIBS]/libqofono/tests
 }
 equals(QT_MAJOR_VERSION, 5): {
     LIBS +=  -lqofono-qt5
     TARGET = tst_qofonotest-qt5
-    target.path = $$INSTALL_ROOT$$PREFIX/lib/libqofono-qt5/tests
+    target.path = $$[QT_INSTALL_LIBS]/libqofono-qt5/tests
 }
 
 CONFIG   += console


### PR DESCRIPTION
Use QT_INSTALL_LIBS for library install paths to enable installation to multi-arch directories. This is a patch forwarded from Ubuntu libqofono packaging, because without it we could not enable proper Multi-Arch support in the packaging.
