### PR TITLE
Added QOfonoConnectionContext::disconnect()

### DIFF
--- a/src/qofonoconnectioncontext.cpp
+++ b/src/qofonoconnectioncontext.cpp
@@ -43,7 +43,6 @@ QOfonoConnectionContext::QOfonoConnectionContext(QObject *parent) :
     QObject(parent),
     d_ptr(new QOfonoConnectionContextPrivate)
 {
-    qDebug() << Q_FUNC_INFO;
 }
 
 QOfonoConnectionContext::~QOfonoConnectionContext()
@@ -72,7 +71,6 @@ void QOfonoConnectionContext::setContextPath(const QString &idPath)
             d_ptr->properties.clear();
         }
 
-qDebug() << Q_FUNC_INFO;
         d_ptr->context = new OfonoConnectionContext("org.ofono", idPath, QDBusConnection::systemBus(),this);
         if (d_ptr->context->isValid()) {
             d_ptr->contextPath = idPath;
@@ -248,14 +246,9 @@ void QOfonoConnectionContext::setActive(const bool value)
 
 void QOfonoConnectionContext::setAccessPointName(const QString &value)
 {
-    if (!active()) {
-        QString str("AccessPointName");
-        QDBusVariant var(value);
-        setOneProperty(str,var);
-    } else {
-     qDebug() << Q_FUNC_INFO  << "is active cannot set APN";
-     Q_EMIT reportError("Context active");
-    }
+    QString str("AccessPointName");
+    QDBusVariant var(value);
+    setOneProperty(str,var);
 }
 
 void QOfonoConnectionContext::setType(const QString &value)
@@ -333,6 +326,12 @@ void QOfonoConnectionContext::setPropertyFinished(QDBusPendingCallWatcher *watch
     }
     Q_EMIT setPropertyFinished();
 
+}
+
+void QOfonoConnectionContext::disconnect()
+{
+    Q_EMIT disconnectRequested();
+    d_ptr->context->SetProperty("Active",QDBusVariant(false)).waitForFinished();
 }
 
 /*

--- a/src/qofonoconnectioncontext.h
+++ b/src/qofonoconnectioncontext.h
@@ -94,6 +94,7 @@ public:
     Q_INVOKABLE void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type=QStringLiteral("internet")); // provision context against mbpi
     #endif
     Q_INVOKABLE void provisionForCurrentNetwork(const QString &type);
+    Q_INVOKABLE void disconnect();
 
 Q_SIGNALS:
     void disconnectRequested();


### PR DESCRIPTION
It may be convenient to synchronously deactivate the context, for example, prior to modifying settings. Other SetProperty calls will fail while context is still active.

Also, it doesn't make sense to check the active status in setAccessPointName because:
- Name isn't the only property that can't be changed while context is active
- It could be that Active has already changed on the ofono side but the property change notification hasn't reached us yet.

Better let ofono check the value of the Active property and make appropriate decision based on that.
