### PR TITLE
scan call should emit _either_ a scanError or scanFinished.

### DIFF
--- a/src/qofononetworkregistration.cpp
+++ b/src/qofononetworkregistration.cpp
@@ -285,9 +285,7 @@ void QOfonoNetworkRegistration::scanFinish(const QArrayOfPathProps &list)
 
 void QOfonoNetworkRegistration::scanError(QDBusError error)
 {
-    qDebug() << Q_FUNC_INFO << error.message();
     Q_EMIT scanError(error.message());
-    Q_EMIT scanFinished();
 }
 
 QString QOfonoNetworkRegistration::currentOperatorPath()


### PR DESCRIPTION
In case of an error, such as 'Operation already in progress', the scan for
the particular call to scan was never started (it ended with an
error) so it can never be finished.

The documentation for callWithCallback states it will call the
error method _instead_ of the return method in the case of an error.

I can see the need for a scanInProgress property or somesuch.
