### PR TITLE
[libqofono] Eliminate dependency on QtXmlPatterns

### DIFF
--- a/rpm/libqofono.spec
+++ b/rpm/libqofono.spec
@@ -12,7 +12,6 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(QtCore)
 BuildRequires:  pkgconfig(QtDBus)
-BuildRequires:  pkgconfig(QtXmlPatterns)
 
 %description
 This package contains Qt bindings for ofono cellular service

--- a/src/qofonoconnectioncontext.cpp
+++ b/src/qofonoconnectioncontext.cpp
@@ -13,7 +13,9 @@
 **
 ****************************************************************************/
 
+#ifdef QOFONO_PROVISIONING
 #include <QtXmlPatterns/QXmlQuery>
+#endif
 
 #include "qofonoconnectioncontext.h"
 #include "dbus/ofonoconnectioncontext.h"
@@ -101,13 +103,6 @@ void QOfonoConnectionContext::setContextPath(const QString &idPath)
                 }
             }
         }
-/*        if (!validateProvisioning()) {
-            provisionForCurrentNetwork(this->type());
-        } else {
-            Q_EMIT reportError("Context provision is not valid");
-            qDebug() << Q_FUNC_INFO << "error Context provision is not valid";
-        }
-*/
     }
 }
 
@@ -343,30 +338,27 @@ void QOfonoConnectionContext::disconnect()
 /*
  * Tries to validate the context against the current registered network
  **/
-//check provision against mbpi
 bool QOfonoConnectionContext::validateProvisioning()
 {
+#ifdef QOFONO_PROVISIONING
     qDebug() << Q_FUNC_INFO << d_ptr->modemPath;
     if (d_ptr->modemPath.isEmpty())
         return false;
-
-    QString provider;
-    QString mcc;
-    QString mnc;
 
     QOfonoNetworkRegistration netReg;
     netReg.setModemPath(d_ptr->modemPath);
     if (netReg.status() == "registered")
         return validateProvisioning(netReg.networkOperators().at(0),netReg.mcc(),netReg.mnc());
+#endif // QOFONO_PROVISIONING
     return false;
 }
 
 /*
  * Tries to validate the context using the provider, mcc and mnc arguments
  **/
-//check provision against mbpi
 bool QOfonoConnectionContext::validateProvisioning(const QString &providerString, const QString &mcc, const QString &mnc)
 {
+#ifdef QOFONO_PROVISIONING
     qDebug() << Q_FUNC_INFO << providerString;
     QXmlQuery query;
     QString provider = providerString;
@@ -449,10 +441,14 @@ bool QOfonoConnectionContext::validateProvisioning(const QString &providerString
 
     //we got here, must be ok
     return true;
+#else // QOFONO_PROVISIONING
+    return false;
+#endif
 }
 
 void QOfonoConnectionContext::provisionForCurrentNetwork(const QString &type)
 {
+#ifdef QOFONO_PROVISIONING
     if (d_ptr->modemPath.isEmpty())
         return;
 
@@ -461,6 +457,7 @@ void QOfonoConnectionContext::provisionForCurrentNetwork(const QString &type)
 
     if (netReg.status() == "registered")
         provision(netReg.name(), netReg.mcc(),netReg.mnc(), type);
+#endif // QOFONO_PROVISIONING
 }
 
 /*
@@ -472,9 +469,9 @@ void QOfonoConnectionContext::provisionForCurrentNetwork(const QString &type)
  * The only way to see if this is a working context is to try to activate the context.
  *
  **/
-// provision context against mbpi
 void QOfonoConnectionContext::provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type)
 {
+#ifdef QOFONO_PROVISIONING
     QXmlQuery query;
     query.setFocus(QUrl("/usr/share/mobile-broadband-provider-info/serviceproviders.xml"));
 
@@ -583,5 +580,6 @@ void QOfonoConnectionContext::provision(const QString &provider, const QString &
     }
     Q_EMIT setPropertyFinished();
     Q_EMIT provisioningFinished();
+#endif // QOFONO_PROVISIONING
 }
 

--- a/src/qofonoconnectioncontext.h
+++ b/src/qofonoconnectioncontext.h
@@ -86,14 +86,15 @@ public:
 
     QString modemPath() const;
 
-    Q_INVOKABLE bool validateProvisioning(); //check provision against mbpi
-    Q_INVOKABLE bool validateProvisioning(const QString &provider, const QString &mcc, const QString &mnc); //check provision against mbpi
+    Q_INVOKABLE QT_DEPRECATED bool validateProvisioning();
+    Q_INVOKABLE QT_DEPRECATED bool validateProvisioning(const QString &provider, const QString &mcc, const QString &mnc);
     #if QT_VERSION < 0x050000
-    Q_INVOKABLE void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type="internet");
+    Q_INVOKABLE QT_DEPRECATED void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type="internet");
     #else
-    Q_INVOKABLE void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type=QStringLiteral("internet")); // provision context against mbpi
+    Q_INVOKABLE QT_DEPRECATED void provision(const QString &provider, const QString &mcc, const QString &mnc, const QString &type=QStringLiteral("internet"));
     #endif
-    Q_INVOKABLE void provisionForCurrentNetwork(const QString &type);
+    Q_INVOKABLE QT_DEPRECATED void provisionForCurrentNetwork(const QString &type);
+
     Q_INVOKABLE void disconnect();
 
 Q_SIGNALS:

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,7 +4,11 @@
 #
 #-------------------------------------------------
 
-QT       += dbus xmlpatterns
+QT += dbus
+
+# QT += xmlpatterns
+# DEFINES += QOFONO_PROVISIONING
+QMAKE_CXXFLAGS += -Wno-unused-parameter
 
 include(version.pri)
 

--- a/test/auto/tests/tst_qofonoconnmancontext.cpp
+++ b/test/auto/tests/tst_qofonoconnmancontext.cpp
@@ -126,6 +126,7 @@ private slots:
 
     }
 
+#ifdef QOFONO_PROVISIONING
     void tst_provisioning()
     {
         QSignalSpy conadd(m, SIGNAL(contextAdded(QString)));
@@ -174,6 +175,7 @@ private slots:
         QCOMPARE(apn.takeFirst().at(0).toString(), QString("test"));
         QCOMPARE(context->validateProvisioning(operatorString, mcc, mnc),false);
     }
+#endif // QOFONO_PROVISIONING
 
 private:
     QOfonoConnectionManager *m;


### PR DESCRIPTION
Please correct me if I'm wrong, but libqofono provisioning doesn't seem to be used anywhere. If so then I suggest to disable it and get rid of dependency on QtXmlPatterns.
