### PR TITLE
Fix crash in QOfonoCallForwarding::isValid()

### DIFF
--- a/src/qofonocallforwarding.cpp
+++ b/src/qofonocallforwarding.cpp
@@ -230,7 +230,7 @@ void QOfonoCallForwarding::disableAll(const QString &type)
 
 bool QOfonoCallForwarding::isValid() const
 {
-    return d_ptr->callForward->isValid();
+    return d_ptr->callForward && d_ptr->callForward->isValid();
 }
 
 bool QOfonoCallForwarding::isReady() const


### PR DESCRIPTION
We shouldn't crash if d_ptr->callForward is NULL (e.g. modem path was never set)
