### PR TITLE
Reduce the object sizes to avoid breaking ABI

### DIFF
--- a/src/qofonoconnectioncontext.h
+++ b/src/qofonoconnectioncontext.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2014 Jolla Ltd.
 ** Contact: lorn.potter@jollamobile.com
 **
 ** GNU Lesser General Public License Usage
@@ -117,9 +117,6 @@ protected:
     QVariant convertProperty(const QString &key, const QVariant &value);
     void propertyChanged(const QString &key, const QVariant &value);
     void objectPathChanged(const QString &path);
-
-private:
-    QOfonoConnectionContextPrivate *d_ptr;
 };
 
 #endif // QOFONOCONNECTIONCONTEXT_H

--- a/src/qofonomessage.cpp
+++ b/src/qofonomessage.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2014 Jolla Ltd.
 ** Contact: lorn.potter@jollamobile.com
 **
 ** GNU Lesser General Public License Usage
@@ -17,8 +17,7 @@
 #include "dbus/ofonomessage.h"
 
 QOfonoMessage::QOfonoMessage(QObject *parent) :
-    QOfonoObject(parent),
-    d_ptr(NULL)
+    QOfonoObject(parent)
 {
 }
 

--- a/src/qofonomessage.h
+++ b/src/qofonomessage.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2014 Jolla Ltd.
 ** Contact: lorn.potter@jollamobile.com
 **
 ** GNU Lesser General Public License Usage
@@ -49,9 +49,6 @@ protected:
     QDBusAbstractInterface* createDbusInterface(const QString &path);
     void propertyChanged(const QString &key, const QVariant &value);
     void objectPathChanged(const QString &path);
-
-private:
-    void *d_ptr;
 };
 
 #endif // QOFONOMessage_H


### PR DESCRIPTION
Version 0.64 breaks ABI by increasing the sizes of QOfonoConnectionContext and QOfonoMessage objects by the size of a pointer (from 12 to 16 bytes on a 32-bit platform).
