### PR TITLE
org.ofono.RadioSettings is a modem interface

### DIFF
--- a/src/qofonoradiosettings.cpp
+++ b/src/qofonoradiosettings.cpp
@@ -16,10 +16,10 @@
 #include "qofonoradiosettings.h"
 #include "dbus/ofonoradiosettings.h"
 
-#define SUPER QOfonoObject
+#define SUPER QOfonoModemInterface
 
 QOfonoRadioSettings::QOfonoRadioSettings(QObject *parent) :
-    SUPER(parent)
+    SUPER(OfonoRadioSettings::staticInterfaceName(), parent)
 {
 }
 
@@ -32,20 +32,14 @@ QDBusAbstractInterface *QOfonoRadioSettings::createDbusInterface(const QString &
     return new OfonoRadioSettings("org.ofono", path, QDBusConnection::systemBus(), this);
 }
 
-void QOfonoRadioSettings::objectPathChanged(const QString &path, const QVariantMap *properties)
-{
-    SUPER::objectPathChanged(path, properties);
-    Q_EMIT modemPathChanged(path);
-}
-
 void QOfonoRadioSettings::setModemPath(const QString &path)
 {
-    setObjectPath(path);
+    SUPER::setModemPath(path);
 }
 
 QString QOfonoRadioSettings::modemPath() const
 {
-    return objectPath();
+    return SUPER::modemPath();
 }
 
 void QOfonoRadioSettings::propertyChanged(const QString &property, const QVariant &value)

--- a/src/qofonoradiosettings.h
+++ b/src/qofonoradiosettings.h
@@ -16,7 +16,7 @@
 #ifndef QOFONORadioSettings_H
 #define QOFONORadioSettings_H
 
-#include "qofonoobject.h"
+#include "qofonomodeminterface.h"
 #include "qofono_global.h"
 
 //! This class is used to access ofono radio settings API
@@ -24,7 +24,7 @@
  * The API is documented in
  * http://git.kernel.org/?p=network/ofono/ofono.git;a=blob_plain;f=doc/radio-settings-api.txt
  */
-class QOFONOSHARED_EXPORT QOfonoRadioSettings : public QOfonoObject
+class QOFONOSHARED_EXPORT QOfonoRadioSettings : public QOfonoModemInterface
 {
     Q_OBJECT
     Q_PROPERTY(QString modemPath READ modemPath WRITE setModemPath NOTIFY modemPathChanged)
@@ -64,7 +64,6 @@ Q_SIGNALS:
 protected:
     QDBusAbstractInterface *createDbusInterface(const QString &path);
     void propertyChanged(const QString &key, const QVariant &value);
-    void objectPathChanged(const QString &path, const QVariantMap *properties);
 };
 
 #endif // QOFONORadioSettings_H


### PR DESCRIPTION
Therefore QOfonoRadioSettings needs to be derived from QOfonoModemInterface. That makes it invalid when org.ofono.RadioSettings is missing from the modem interface list.

It fixes runtime warnings like this:

[D] QOfonoObject::getPropertiesFinished:182 - QDBusError("org.freedesktop.DBus.Error.UnknownMethod", "Method "GetProperties" with signature "" on interface "org.ofono.RadioSettings" doesn't exist") 