### PR TITLE
Don't discard property values when SIM card is removed

### DIFF
--- a/src/qofonosimmanager.cpp
+++ b/src/qofonosimmanager.cpp
@@ -127,25 +127,7 @@ void QOfonoSimManager::propertyChanged(const QString &property, const QVariant &
 {
     SUPER::propertyChanged(property, value);
     if (property == kPresent) {
-        const bool present = value.value<bool>();
-        Q_EMIT presenceChanged(present);
-        if (!present) {
-            // When "Present" becomes false, ofono stops reporting other
-            // properties, essentially meaning that for any practical purpose
-            // they no longer exist. There's no "PropertyRemoved" signal in
-            // the ofono API though, so we have to remove them from our cache
-            // manually. After SIM inserted and "Present" becomes true again,
-            // ofono is supposed to send "PropertyChanged" signal for each
-            // property and that will re-populate our property cache.
-            QStringList keys = getProperties().keys();
-            const int n = keys.count();
-            for (int i=0; i<n; i++) {
-                QString otherKey = keys.at(i);
-                if (otherKey != kPresent) {
-                    removeProperty(otherKey);
-                }
-            }
-        }
+        Q_EMIT presenceChanged(value.toBool());
     } else if (property == kSubscriberIdentity) {
         Q_EMIT subscriberIdentityChanged(value.value<QString>());
     } else if (property == kMobileCountryCode) {


### PR DESCRIPTION
The assumption was that ofono would resend PropertyChanged signal for each property after SIM card is inserted. In practice, it doesn't do it for all properties. We ended up losing some of them which could result in all sorts of weird behaviour.