### PR TITLE
Mark QOfonoModem and other objects invalid if modem goes away

### DIFF
--- a/src/qofonomanager.cpp
+++ b/src/qofonomanager.cpp
@@ -167,3 +167,14 @@ void QOfonoManager::ofonoUnregistered(const QString &)
         }
     }
 }
+
+QSharedPointer<QOfonoManager> QOfonoManager::instance()
+{
+    static QWeakPointer<QOfonoManager> sharedInstance;
+    QSharedPointer<QOfonoManager> mgr = sharedInstance;
+    if (mgr.isNull()) {
+        mgr = QSharedPointer<QOfonoManager>::create();
+        sharedInstance = mgr;
+    }
+    return mgr;
+}

--- a/src/qofonomanager.h
+++ b/src/qofonomanager.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2013-2014 Jolla Ltd.
+** Copyright (C) 2013-2015 Jolla Ltd.
 ** Contact: lorn.potter@jollamobile.com
 **
 ** GNU Lesser General Public License Usage
@@ -39,6 +39,8 @@ public:
     QString defaultModem();
     bool available() const;
     bool isValid() const;
+
+    static QSharedPointer<QOfonoManager> instance();
 
 Q_SIGNALS: // SIGNALS
     void modemAdded(const QString &modem);

--- a/src/qofonomessagemanager.cpp
+++ b/src/qofonomessagemanager.cpp
@@ -166,13 +166,13 @@ void QOfonoMessageManager::onGetMessagesFinished(QDBusPendingCallWatcher *watch)
         qDebug() << reply.error();
         Q_EMIT reportError(reply.error().message());
     } else {
+        ValidTracker valid(this);
         ObjectPathPropertiesList list = reply.value();
         privateData()->initialized = true;
         for (int i=0; i<list.count(); i++) {
             addMessage(list[i].path.path());
         }
         Q_EMIT messagesFinished();
-        if (isValid()) validChanged(true);
     }
 }
 

--- a/src/qofonomodem.h
+++ b/src/qofonomodem.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2013-2014 Jolla Ltd.
+** Copyright (C) 2013-2015 Jolla Ltd.
 ** Contact: lorn.potter@jollamobile.com
 **
 ** GNU Lesser General Public License Usage
@@ -93,10 +93,17 @@ Q_SIGNALS:
     void interfacesChanged(const QStringList &interfaces);
     void modemPathChanged(const QString &path);
 
+private Q_SLOTS:
+    bool checkModemPathValidity();
+
 protected:
     QDBusAbstractInterface *createDbusInterface(const QString &path);
     void propertyChanged(const QString &key, const QVariant &value);
     void objectPathChanged(const QString &path, const QVariantMap *properties);
+
+private:
+    class Private;
+    Private* privateData() const;
 };
 
 #endif // QOFONOMODEM_H

--- a/src/qofonomodeminterface.h
+++ b/src/qofonomodeminterface.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2014 Jolla Ltd.
+** Copyright (C) 2014-2015 Jolla Ltd.
 ** Contact: slava.monich@jolla.com
 **
 ** GNU Lesser General Public License Usage
@@ -39,6 +39,9 @@ protected:
 
     bool isReady() const;
 
+public:
+    bool isValid() const;
+
 Q_SIGNALS:
     void modemPathChanged(const QString &path);
     void readyChanged(/* No parameter for historical reasons */);
@@ -48,8 +51,9 @@ protected:
     void updateProperty(const QString &key, const QVariant &value);
     void objectPathChanged(const QString &path, const QVariantMap *properties);
 
-private slots:
+private Q_SLOTS:
     void onModemInterfacesChanged(const QStringList &interfaces);
+    void onModemValidChanged(bool valid);
 
 private:
     class Private;

--- a/src/qofononetworkregistration.cpp
+++ b/src/qofononetworkregistration.cpp
@@ -289,9 +289,9 @@ void QOfonoNetworkRegistration::onGetOperatorsFinished(QDBusPendingCallWatcher *
         qDebug() << reply.error();
         Q_EMIT reportError(reply.error().message());
     } else {
+        ValidTracker valid(this);
         privateData()->initialized = true;
         onOperatorsChanged(reply.value());
-        if (isValid()) validChanged(true);
     }
 }
 

--- a/src/qofonoobject.h
+++ b/src/qofonoobject.h
@@ -23,6 +23,16 @@ class QOfonoObject : public QObject
     Q_OBJECT
     Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)
 
+protected:
+    friend class ValidTracker;
+    class ValidTracker {
+    private:
+        QOfonoObject* object;
+    public:
+        ValidTracker(QOfonoObject* object);
+        ~ValidTracker();
+    };
+
 public:
     class ExtData {
     public:

--- a/src/qofonovoicecallmanager.cpp
+++ b/src/qofonovoicecallmanager.cpp
@@ -272,12 +272,12 @@ void QOfonoVoiceCallManager::onGetCallsFinished(QDBusPendingCallWatcher *watch)
         qDebug() << reply.error();
         Q_EMIT reportError(reply.error().message());
     } else {
+        ValidTracker valid(this);
         ObjectPathPropertiesList list = reply.value();
         privateData()->initialized = true;
         for (int i=0; i<list.count(); i++) {
             addCall(list[i].path.path());
         }
-        if (isValid()) validChanged(true);
     }
 }
 


### PR DESCRIPTION
This allows UI to behave reasonably when the modems get added/removed dynamically (or ofono crashes).

Similarly, connection context is marked invalid when SIM is removed.

The ValidTracker mechanism eliminates unnecessary `validChanged()` signals.