### PR TITLE
Fix problems with QOfonoSimWatcher deleting QOfonoSimManager at wrong time

### DIFF
--- a/src/qofonosimmanager.h
+++ b/src/qofonosimmanager.h
@@ -44,6 +44,8 @@ class QOFONOSHARED_EXPORT QOfonoSimManager : public QOfonoModemInterface
     Q_PROPERTY(bool barredDialing READ barredDialing NOTIFY barredDialingChanged)
 
 public:
+    class SharedPointer;
+
     enum Error {
         NoError,
         NotImplementedError,
@@ -145,6 +147,12 @@ private slots:
     void resetPinCallFinished(QDBusPendingCallWatcher *call);
     void lockPinCallFinished(QDBusPendingCallWatcher *call);
     void unlockPinCallFinished(QDBusPendingCallWatcher *call);
+};
+
+// Unlike the default QSharedPointer, deletes QOfonoSimManager with deleteLater
+class QOFONOSHARED_EXPORT QOfonoSimManager::SharedPointer : public QSharedPointer<QOfonoSimManager> {
+public:
+    SharedPointer(QOfonoSimManager * ptr = NULL) : QSharedPointer<QOfonoSimManager>(ptr, &QObject::deleteLater) {}
 };
 
 #endif // QOFONOSimManager_H

--- a/src/qofonosimwatcher.cpp
+++ b/src/qofonosimwatcher.cpp
@@ -24,8 +24,8 @@ public:
 
     QOfonoSimWatcher *watcher;
     QSharedPointer<QOfonoManager> ofono;
-    QHash<QString, QSharedPointer<QOfonoSimManager> > allSims;
-    QList<QSharedPointer<QOfonoSimManager> > presentSims;
+    QHash<QString, QOfonoSimManager::SharedPointer> allSims;
+    QList<QOfonoSimManager::SharedPointer> presentSims;
     bool valid;
 
 private Q_SLOTS:
@@ -85,11 +85,11 @@ void QOfonoSimWatcher::Private::updateModems()
             QString path(newModems.at(i));
             if (!allSims.contains(path)) {
                 // This is a new modem
-                QOfonoSimManager *sim = new QOfonoSimManager(this);
+                QOfonoSimManager *sim = new QOfonoSimManager();
                 sim->fixModemPath(path);
                 connect(sim, SIGNAL(validChanged(bool)), SLOT(updateSims()));
                 connect(sim, SIGNAL(presenceChanged(bool)), SLOT(updateSims()));
-                allSims.insert(path, QSharedPointer<QOfonoSimManager>(sim));
+                allSims.insert(path, QOfonoSimManager::SharedPointer(sim));
             }
         }
         updateSims();
@@ -98,12 +98,12 @@ void QOfonoSimWatcher::Private::updateModems()
 
 void QOfonoSimWatcher::Private::updateSims()
 {
-    QList<QSharedPointer<QOfonoSimManager> > sims;
+    QList<QOfonoSimManager::SharedPointer> sims;
     QStringList modems = allSims.keys();
     modems.sort();
     int i, n = modems.count();
     for (i=0; i<n; i++) {
-        QSharedPointer<QOfonoSimManager> sim = allSims.value(modems.at(i));
+        QOfonoSimManager::SharedPointer sim = allSims.value(modems.at(i));
         if (sim->isValid() && sim->present()) {
             sims.append(sim);
         }
@@ -130,7 +130,7 @@ void QOfonoSimWatcher::Private::updateValid()
     // This object is valid if QOfonoManager and all SIM managers are valid.
     bool isValid = ofono->available();
     if (isValid) {
-        QList<QSharedPointer<QOfonoSimManager> > sims = allSims.values();
+        QList<QOfonoSimManager::SharedPointer> sims = allSims.values();
         const int n = sims.count();
         for (int i=0; i<n && isValid; i++) {
             isValid = sims.at(i)->isValid();
@@ -163,7 +163,7 @@ int QOfonoSimWatcher::presentSimCount() const
     return d_ptr->presentSims.count();
 }
 
-QList<QSharedPointer<QOfonoSimManager> > QOfonoSimWatcher::presentSimList() const
+QList<QOfonoSimManager::SharedPointer> QOfonoSimWatcher::presentSimList() const
 {
     return d_ptr->presentSims;
 }

--- a/src/qofonosimwatcher.h
+++ b/src/qofonosimwatcher.h
@@ -32,7 +32,7 @@ public:
 
     bool isValid() const;
     int presentSimCount() const;
-    QList<QSharedPointer<QOfonoSimManager> > presentSimList() const;
+    QList<QOfonoSimManager::SharedPointer> presentSimList() const;
 
 Q_SIGNALS:
     void validChanged();


### PR DESCRIPTION
Trying to actually use this `QOfonoSimWatcher` thing, I faced a few problems which didn't show up in the test app. One was a clear mistake - `QOfonoSimManager` managed by `QSharedPointer` can't have a parent. The second one wasn't so obvious. It had to do with `QOfonoSimManager` issuing a property change signal and the object which handles it (`QOfonoSimWatcher`) dropping the last reference to `QOfonoSimManager` and therefore deleting it. That was causing a crash as the stack unrolls:

```
==21336== Invalid read of size 4
==21336==    at 0x7EB02D0: QOfonoModemInterface::isReady() const
==21336==    by 0x7EB042B: QOfonoModemInterface::getPropertiesFinished(QMap<QString, QVariant> const&, QDBusError const*)
==21336==    by 0x7EA3CD7: QOfonoObject::onGetPropertiesFinished(QDBusPendingCallWatcher*)
==21336==    by 0x7EE4943: QOfonoObject::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)
==21336==    by 0x4DF914F: QMetaObject::activate(QObject*, int, int, void**)
==21336==    by 0x4C041AF: QDBusPendingCallWatcher::finished(QDBusPendingCallWatcher*)
==21336==    by 0x4C05489: _q_finished
==21336==    by 0x4C05489: QDBusPendingCallWatcher::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)
==21336==    by 0x4DF9D61: QObject::event(QEvent*)
==21336==    by 0x4DDA4D3: QCoreApplication::notify(QObject*, QEvent*)
==21336==    by 0x4DDA2A5: QCoreApplication::notifyInternal(QObject*, QEvent*)
==21336==    by 0x4DDC233: sendEvent
==21336==    by 0x4DDC233: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)
==21336==    by 0x4E14C87: postEventSourceDispatch(_GSource*, int (*)(void*), void*)
==21336==  Address 0x82c4f48 is 0 bytes inside a block of size 12 free'd
==21336==    at 0x4841050: operator delete(void*)
==21336==    by 0x7ECDE8B: QOfonoSimManager::~QOfonoSimManager()
==21336==    by 0x7ED90A7: QtSharedPointer::CustomDeleter<QOfonoSimManager, QtSharedPointer::NormalDeleter>::execute()
==21336==    by 0x7ED8D43: QtSharedPointer::ExternalRefCountWithCustomDeleter<QOfonoSimManager, QtSharedPointer::NormalDeleter>::deleter(QtSharedPointer::ExternalRefCountData*)
==21336==    by 0x7EAA4EF: QtSharedPointer::ExternalRefCountData::destroy()
==21336==    by 0x7ED8CAB: QSharedPointer<QOfonoSimManager>::deref(QtSharedPointer::ExternalRefCountData*)
==21336==    by 0x7ED8383: QSharedPointer<QOfonoSimManager>::deref()
==21336==    by 0x7ED774B: QSharedPointer<QOfonoSimManager>::~QSharedPointer()
==21336==    by 0x7ED8AC3: QList<QSharedPointer<QOfonoSimManager> >::node_destruct(QList<QSharedPointer<QOfonoSimManager> >::Node*, QList<QSharedPointer<QOfonoSimManager> >::Node*)
==21336==    by 0x7ED7E9F: QList<QSharedPointer<QOfonoSimManager> >::dealloc(QListData::Data*)
==21336==    by 0x7ED7473: QList<QSharedPointer<QOfonoSimManager> >::~QList()
==21336==    by 0x7ED6D17: QOfonoSimWatcher::Private::updateSims()
```

The solution to that is to use `QObject::deleteLater` as the deleter for shared pointer. Now `QOfonoSimWatcher` should be usable.