### PR TITLE
Fix nemo-transfer-engine crashes

### DIFF
--- a/src/qofonomanager.cpp
+++ b/src/qofonomanager.cpp
@@ -106,6 +106,7 @@ void QOfonoManager::onModemRemoved(const QDBusObjectPath& path)
 void QOfonoManager::onGetModemsFinished(QDBusPendingCallWatcher* watcher)
 {
     QDBusPendingReply<ObjectPathPropertiesList> reply(*watcher);
+    watcher->deleteLater();
     if (reply.isValid() && !reply.isError()) {
         QString prevDefault = defaultModem();
         QStringList newModems;
@@ -124,7 +125,6 @@ void QOfonoManager::onGetModemsFinished(QDBusPendingCallWatcher* watcher)
         d_ptr->available = true;
         Q_EMIT availableChanged(true);
     }
-    watcher->deleteLater();
 }
 
 void QOfonoManager::connectToOfono(const QString &)

--- a/src/qofonosimwatcher.cpp
+++ b/src/qofonosimwatcher.cpp
@@ -36,7 +36,6 @@ private Q_SLOTS:
 };
 
 QOfonoSimWatcher::Private::Private(QOfonoSimWatcher *parent) :
-    QObject(parent),
     watcher(parent),
     ofono(QOfonoManager::instance()),
     valid(false)
@@ -58,8 +57,12 @@ void QOfonoSimWatcher::Private::onOfonoAvailableChanged()
         allSims.clear();
         if (!presentSims.isEmpty()) {
             presentSims.clear();
-            Q_EMIT watcher->presentSimListChanged();
-            Q_EMIT watcher->presentSimCountChanged();
+            if (watcher) {
+                Q_EMIT watcher->presentSimListChanged();
+            }
+            if (watcher) {
+                Q_EMIT watcher->presentSimCountChanged();
+            }
         }
     }
 }
@@ -110,14 +113,20 @@ void QOfonoSimWatcher::Private::updateSims()
     }
     if (sims.count() != presentSims.count()) {
         presentSims = sims;
-        Q_EMIT watcher->presentSimListChanged();
-        Q_EMIT watcher->presentSimCountChanged();
+        if (watcher) {
+            Q_EMIT watcher->presentSimListChanged();
+        }
+        if (watcher) {
+            Q_EMIT watcher->presentSimCountChanged();
+        }
     } else {
         n = sims.count();
         for (i=0; i<n; i++) {
             if (sims.at(i).data() != presentSims.at(i).data()) {
                 presentSims = sims;
-                Q_EMIT watcher->presentSimListChanged();
+                if (watcher) {
+                    Q_EMIT watcher->presentSimListChanged();
+                }
                 break;
             }
         }
@@ -138,7 +147,9 @@ void QOfonoSimWatcher::Private::updateValid()
     }
     if (valid != isValid) {
         valid = isValid;
-        Q_EMIT watcher->validChanged();
+        if (watcher) {
+            Q_EMIT watcher->validChanged();
+        }
     }
 }
 
@@ -150,7 +161,8 @@ QOfonoSimWatcher::QOfonoSimWatcher(QObject *parent) :
 
 QOfonoSimWatcher::~QOfonoSimWatcher()
 {
-    // d_ptr is a child object, it gets deleted automatically
+    d_ptr->watcher = NULL;
+    d_ptr->deleteLater();
 }
 
 bool QOfonoSimWatcher::isValid() const


### PR DESCRIPTION
Basically, if a QObject emits a signal, the signal handler can directly or indirectly delete QObject that issued the signal. Normally, this sort of problem is easy to resolve by temporarily incrementing object's refcount but since QObject isn't refcountable... I couldn't come up with anything better than this.

Each of these commits would fix the crash in question but they both make sense to me, I couldn't decide which one is better and left both in.
